### PR TITLE
Fjern im-bro-spinn fra redis

### DIFF
--- a/deploy/redis-config.yml
+++ b/deploy/redis-config.yml
@@ -29,7 +29,6 @@ spec:
       rules:
         - application: im-aktiveorgnrservice
         - application: im-api
-        - application: im-bro-spinn
         - application: im-innsending
         - application: im-inntekt-selvbestemt-service
         - application: im-inntektservice


### PR DESCRIPTION
im-bro-spinn bruker ikke redis lengre og trenger ikke denne tilgangen